### PR TITLE
Allow configuration of the SNTP request

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ android {
 }
 
 dependencies {
-    implementation "com.github.instacart.truetime-android:library-extension-rx:09087b6a6e"
+    implementation "com.github.instacart.truetime-android:library-extension-rx:3.4"
     implementation "io.reactivex.rxjava2:rxandroid:2.0.1"
 }

--- a/android/src/main/java/tv/orale/truetime/TrueTimePlugin.java
+++ b/android/src/main/java/tv/orale/truetime/TrueTimePlugin.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.instacart.library.truetime.TrueTimeRx;
 
 import java.util.Date;
+import java.util.Map;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -32,11 +33,14 @@ public class TrueTimePlugin implements MethodCallHandler {
     public void onMethodCall(MethodCall call, final Result result) {
         switch (call.method) {
             case "init":
+                if (!(call.arguments instanceof Map)) {
+                    throw new IllegalArgumentException("Map argument expected");
+                }
                 TrueTimeRx.build()
-                        .withConnectionTimeout(1_000)
-                        .withRetryCount(3)
-                        .withLoggingEnabled(true)
-                        .initializeRx("time.google.com")
+                        .withConnectionTimeout((int) call.argument("timeout"))
+                        .withRetryCount((int) call.argument("retryCount"))
+                        .withLoggingEnabled((Boolean) call.argument("logging"))
+                        .initializeRx((String) call.argument("ntpServer"))
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(new Consumer<Date>() {

--- a/lib/true_time.dart
+++ b/lib/true_time.dart
@@ -11,9 +11,25 @@ class TrueTime {
 
   /// Returns `true` if TrueTime was initialized.
   /// This function must be called and verified to have returned true before any call to [now] is made.
-  static Future<bool> init() async {
+  static Future<bool> init({
+    int timeout = 5000,
+    int retryCount = 3,
+    bool logging = true,
+    String ntpServer = 'ntp.google.com',
+  }) async {
+    assert(timeout > 0);
+    assert(retryCount >= 0);
+    assert(ntpServer != null);
+    assert(ntpServer.isNotEmpty);
+    final Map<String, dynamic> params = <String, dynamic>{
+      'timeout': timeout,
+      'retryCount': retryCount,
+      'logging': logging,
+      'ntpServer': ntpServer,
+    };
+
     try {
-      return await _channel.invokeMethod('init');
+      return await _channel.invokeMethod('init', params);
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
TrueTime's API accepts several parameters regarding the SNTP request
which we should allow clients to change. This change adds
support for passing configuration to the Android implementation of
this library, the iOS TrueTime library doesn't support configuration
so this is a NoOp.